### PR TITLE
Update plugin builds to use the netgo tag for all the architectures

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -18,6 +18,8 @@ builds:
 
     id: "steampipe"
     binary: "{{ .ProjectName }}.plugin"
+    flags:
+      - -tags=netgo
 
 archives:
   - format: gz

--- a/Makefile
+++ b/Makefile
@@ -1,2 +1,4 @@
+STEAMPIPE_INSTALL_DIR ?= ~/.steampipe
+BUILD_TAGS = netgo
 install:
-	go build -o ~/.steampipe/plugins/hub.steampipe.io/plugins/turbot/linode@latest/steampipe-plugin-linode.plugin *.go
+	go build -o $(STEAMPIPE_INSTALL_DIR)/plugins/hub.steampipe.io/plugins/turbot/linode@latest/steampipe-plugin-linode.plugin -tags "${BUILD_TAGS}" *.go


### PR DESCRIPTION
# Example query results
<details>
  <summary>Results</summary>
  
```
Add example SQL query results here (please include the input queries as well)
```
</details>
